### PR TITLE
fix formatting for result page

### DIFF
--- a/src/pages/Result/index.tsx
+++ b/src/pages/Result/index.tsx
@@ -37,10 +37,6 @@ const Result = () => {
         You scored {score} out of 10!
       </h2>
 
-      <h3>
-        {getResultText()}
-      </h3>
-
       <img
         src="/img/result-image.png" 
         alt="Result"
@@ -52,6 +48,10 @@ const Result = () => {
           marginBottom: "20px",
         }}
       />
+
+      <p style={{ fontSize: "18px", fontWeight: "bold", marginTop: "20px" }}>
+        {getResultText()}
+      </p>
 
       <button
         onClick={handlePlayAgain}


### PR DESCRIPTION
Change dynamic text to a p tag and move it under the image placeholder so it's no longer in line with the play again button 
<img width="922" height="699" alt="Screenshot 2025-08-25 at 3 17 43 PM" src="https://github.com/user-attachments/assets/09f730a3-fcce-4137-a593-ef1f11b3b0a3" />
