### PR TITLE
Display the entire results image

### DIFF
--- a/src/pages/Result/index.tsx
+++ b/src/pages/Result/index.tsx
@@ -68,13 +68,6 @@ const Result = () => {
       <img
         src={imageUrl}
         alt="Results"
-        style={{
-          width: "400px",
-          height: "400px",
-          objectFit: "cover",
-          borderRadius: "10px",
-          marginBottom: "20px",
-        }}
       />
 
       <p style={{ fontSize: "22px", fontWeight: "bold", marginTop: "20px" }}>


### PR DESCRIPTION
Just display the entire results image 
<img width="1001" height="1017" alt="Screenshot 2025-08-27 at 1 44 50 PM" src="https://github.com/user-attachments/assets/ba8b6730-6cf8-4515-9915-83f9b24abb78" />
and don't fit it into a box. 
It cuts off some of the poster which is undesirable. 

